### PR TITLE
Step6 Ruby version patch

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM       ruby:2
+FROM       ruby:2.6
 LABEL      maintainer="Sawood Alam <@ibnesayeed>"
 
 ENV        LANG C.UTF-8


### PR DESCRIPTION
Pinned ruby base image to Ruby:2.6 due to https://github.com/ibnesayeed/linkextractor/issues/6