### PR TITLE
linkextractor-api should expose port 5000 only inside container,

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   api:
     image: linkextractor-api:step4-python
     build: ./api
-    ports:
-      - "5000:5000"
+    expose:
+      - "5000"
   web:
     image: php:7-apache
     ports:


### PR DESCRIPTION
hence replacing 'ports' with 'expose' in docker-compose.yml.
This would imply a small change in 
play-with-docker.github.io/_posts/2018-09-22-microservice-orchestration.markdown 
as well to explain the nuance.
So this should be replace as well:
```
We should now be able to talk to the API service as before:
curl -i http://localhost:5000/api/http://example.com/
```
with something like
The PHP web server will access the API which is no longer exposed outside the container.
